### PR TITLE
Fixed issues with CMakeLists.txt for the psvita version

### DIFF
--- a/psvita/CMakeLists.txt
+++ b/psvita/CMakeLists.txt
@@ -37,10 +37,12 @@ add_executable(${VITA_APP_NAME}
 )
 
 target_link_libraries(${VITA_APP_NAME}
+  soloud
   SceLibKernel_stub
   SceDisplay_stub
   SceTouch_stub
   SceAudio_stub
+  SceAppMgr_stub
   -lvita2d 
   -lSceDisplay_stub 
   -lSceGxm_stub
@@ -49,13 +51,14 @@ target_link_libraries(${VITA_APP_NAME}
   -lScePgf_stub
   -lScePvf_stub
   -lSceCommonDialog_stub
+  -lSceAppMgr_stub
   -lfreetype
   -lpng
   -ljpeg
   -lz
   -lm
   -lc
-  soloud
+  -lbz2
   pthread
   m
 )
@@ -71,5 +74,6 @@ vita_create_vpk(${SHORT_NAME}.vpk ${VITA_TITLEID} ${SHORT_NAME}.self
   FILE sce_sys/livearea/contents/bg0.png sce_sys/livearea/contents/bg0.png
   FILE sce_sys/livearea/contents/startup.png sce_sys/livearea/contents/startup.png
   FILE sce_sys/livearea/contents/template.xml sce_sys/livearea/contents/template.xml
+  FILE src/resources resources
 )
 


### PR DESCRIPTION
**Fixed issues with CMakeLists.txt for the psvita version**
- Fixed: library linking
- Fixed: resources folder inclusion when creating the .VPk

___

The PS Vita version of the game was giving me issues during the building process due to library linking being done incorrectly. I also noticed that the resources folder was not included when creating the .VPK file. 

The following changes allowed me to successfully build, install and play the game on my Vita 👍